### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "composer",
     "name_pretty": "Cloud Composer",
     "product_documentation": "https://cloud.google.com/composer/",
-    "client_documentation": "https://googleapis.dev/python/composer/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/composer/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ schedule, and monitor pipelines.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-orchestration-airflow.svg
    :target: https://pypi.org/project/google-cloud-orchestration-airflow/
 .. _Cloud Composer: https://cloud.google.com/composer
-.. _Client Library Documentation: https://googleapis.dev/python/composer/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/composer/latest
 .. _Product Documentation:  https://cloud.google.com/composer/docs
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.